### PR TITLE
(BOLT-519) Fix User-Agent dependency on VERSION

### DIFF
--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'orchestrator_client/version'
 
 class OrchestratorClient::Config
 


### PR DESCRIPTION
The default config sets User-Agent based on orchestrator-client's
VERSION, but never requires the file that defines it. That results in
users having to explicitly require `orchestrator_client/version` as
well or they get an error that `OrchestratorClient::VERSION` is
undefined when configuring it. Add a require before use.