### PR TITLE
(BOLT-686) Use TLS v1.2

### DIFF
--- a/lib/orchestrator_client.rb
+++ b/lib/orchestrator_client.rb
@@ -24,7 +24,7 @@ class OrchestratorClient
   def create_http(uri)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    http.ssl_version = :TLSv1
+    http.ssl_version = :TLSv1_2
     http.ca_file = config['cacert']
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http


### PR DESCRIPTION
All Orchestrator releases support TLS v1.2. Some are now being
configured to disable TLS v1. Update the client to always use TLS v1.2
so it works with servers that have disabled earlier versions of TLS.