### PR TITLE
Switch to using persistent HTTP connections

### DIFF
--- a/lib/orchestrator_client/error.rb
+++ b/lib/orchestrator_client/error.rb
@@ -17,7 +17,7 @@ class OrchestratorClient::ApiError < RuntimeError
     rescue
       return OrchestratorClient::BadResponse.new("Response body was not valid JSON: #{res.body}")
     end
-    code = res.code
+    code = res.status
 
     case data['kind']
     when 'puppetlabs.validators/validation-error'

--- a/orchestrator_client.gemspec
+++ b/orchestrator_client.gemspec
@@ -14,4 +14,7 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/puppetlabs/orchestrator_client-ruby'
   s.license       = "Apache-2.0"
   s.require_paths = ["lib"]
+
+  s.add_dependency 'faraday'
+  s.add_dependency 'net-http-persistent'
 end

--- a/spec/unit/error_spec.rb
+++ b/spec/unit/error_spec.rb
@@ -25,9 +25,9 @@ describe OrchestratorClient::ApiError do
   describe "::make_error_from_response" do
     before(:all) do
       class FakeResponse
-        attr_reader :code, :body
+        attr_reader :status, :body
         def initialize(error)
-          @code = '400'
+          @status = 400
           @body = "{\"kind\":\"#{error}\"}"
         end
       end


### PR DESCRIPTION
When running a series of very quick tasks with a short polling
interval the overhead of re-establishing the TCP connection
starts to show. On a series of test runs with 13 tasks less than
a second in duration with a 0.1s polling interval using a
persistent HTTP connection showed about a 8-9% performance
improvement.