### PR TITLE
(BOLT-1076) Clear error when illegal characters are in token

### DIFF
--- a/lib/orchestrator_client.rb
+++ b/lib/orchestrator_client.rb
@@ -21,10 +21,6 @@ class OrchestratorClient
     @http = create_http(config.root_url)
   end
 
-  def make_uri(path)
-    URI.parse("#{config.root_url}#{path}")
-  end
-
   def create_http(root_url)
     Faraday.new(url: root_url) do |f|
       f.headers['Content-Type'] = 'application/json'

--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -77,7 +77,16 @@ class OrchestratorClient::Config
   end
 
   def load_token
-    @config['token'] || File.open(config['token-file']) { |f| f.read.strip }
+    if @config['token']
+      @config['token']
+    else
+      token = File.open(config['token-file']) { |f| f.read.strip }
+      if token != URI.escape(token)
+        raise OrchestratorClient::ConfigError.new("'#{config['token-file']}' contains illegal characters")
+      end
+      @config['token'] = token
+      @config['token']
+    end
   end
 
   def token

--- a/spec/unit/orchestrator_client_spec.rb
+++ b/spec/unit/orchestrator_client_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe OrchestratorClient do
 
@@ -31,6 +32,20 @@ describe OrchestratorClient do
     it "complains when a configuration value for 'cacert' is not provided" do
       @config.delete('cacert')
       expect{ OrchestratorClient.new({'cacert' => nil, 'service-url' => 'https://example.com'}) }.to raise_error("'cacert' is required in config")
+    end
+  end
+
+  context "When loading a token from file" do
+    it "complains when illegal characters are detected" do
+      @config.delete('token')
+      token_file = Tempfile.new('bad_token')
+      token_file.write("oops\nbadchars")
+      token_file.flush
+      @config['token-file'] = token_file.path
+      @orchestrator_api = OrchestratorClient.new(@config)
+      expect{ @orchestrator_api.config.token }.to raise_error("'#{token_file.path}' contains illegal characters")
+      token_file.close
+      token_file.unlink
     end
   end
 


### PR DESCRIPTION
This commit adds a check to detect illegal characters in token files. This will help users identify the error quickly by providing the path to the file the bad token was loaded from.