### PR TITLE
(BOLT-1076) Update test to catch expected exception on init

### DIFF
--- a/spec/unit/orchestrator_client_spec.rb
+++ b/spec/unit/orchestrator_client_spec.rb
@@ -42,8 +42,7 @@ describe OrchestratorClient do
       token_file.write("oops\nbadchars")
       token_file.flush
       @config['token-file'] = token_file.path
-      @orchestrator_api = OrchestratorClient.new(@config)
-      expect{ @orchestrator_api.config.token }.to raise_error("'#{token_file.path}' contains illegal characters")
+      expect{ OrchestratorClient.new(@config) }.to raise_error("'#{token_file.path}' contains illegal characters")
       token_file.close
       token_file.unlink
     end


### PR DESCRIPTION
After rebasing this work on the persistent-http change the token file is now read on init. This commit updates the test to expect the error upon initialization of an OrchestratorClient object.