### PR TITLE
(BOLT-1076) Do not use persistent http on windows

### DIFF
--- a/lib/orchestrator_client.rb
+++ b/lib/orchestrator_client.rb
@@ -3,7 +3,6 @@ require 'uri'
 require 'json'
 require 'openssl'
 require 'faraday'
-require 'net/http/persistent'
 
 class OrchestratorClient
   require 'orchestrator_client/error'
@@ -28,8 +27,13 @@ class OrchestratorClient
       f.headers['User-Agent'] = config['User-Agent']
       f.ssl['ca_file'] = config['cacert']
       f.ssl['version'] = :TLSv1_2
-      f.adapter :net_http_persistent, pool_size: 5 do |http|
-        http.idle_timeout = 30
+      # Do not use net-http-persistent on windows
+      if !!File::ALT_SEPARATOR
+        f.adapter :net_http
+      else
+        f.adapter :net_http_persistent, pool_size: 5 do |http|
+          http.idle_timeout = 30
+        end
       end
     end
   end

--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -89,12 +89,16 @@ class OrchestratorClient::Config
     if @config['token']
       @config['token']
     else
-      token = File.open(config['token-file']) { |f| f.read.strip }
-      if token != URI.escape(token)
-        raise OrchestratorClient::ConfigError.new("'#{config['token-file']}' contains illegal characters")
+      begin
+        token = File.open(config['token-file']) { |f| f.read.strip }
+        if token != URI.escape(token)
+          raise OrchestratorClient::ConfigError.new("token-file '#{config['token-file']}' contains illegal characters")
+        end
+        @config['token'] = token
+        @config['token']
+      rescue Errno::ENOENT
+        raise OrchestratorClient::ConfigError.new("token-file '#{config['token-file']}' is unreadable")
       end
-      @config['token'] = token
-      @config['token']
     end
   end
 

--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -63,6 +63,15 @@ class OrchestratorClient::Config
       raise OrchestratorClient::ConfigError.new("'service-url' is required in config")
     end
 
+    begin
+      service_url = URI.parse(config['service-url'])
+      unless service_url.kind_of?(URI::HTTP) || service_url.kind_of?(URI::HTTPS)
+        raise OrchestratorClient::ConfigError.new("'#{config['service-url']}' is an invalid service-url")
+      end
+    rescue URI::InvalidURIError
+      raise OrchestratorClient::ConfigError.new("'#{config['service-url']}' is an invalid service-url")
+    end
+
     if config['cacert'].nil?
       raise  OrchestratorClient::ConfigError.new("'cacert' is required in config")
     end

--- a/spec/unit/orchestrator_client_spec.rb
+++ b/spec/unit/orchestrator_client_spec.rb
@@ -29,6 +29,12 @@ describe OrchestratorClient do
       expect{ OrchestratorClient.new(@config) }.to raise_error("'service-url' is required in config")
     end
 
+    it "complains when an invalid 'service-url' is provided" do
+      @config.delete('service-url')
+      @config['service-url'] = 'foo'
+      expect{ OrchestratorClient.new(@config) }.to raise_error("'#{@config['service-url']}' is an invalid service-url")
+    end
+
     it "complains when a configuration value for 'cacert' is not provided" do
       @config.delete('cacert')
       expect{ OrchestratorClient.new({'cacert' => nil, 'service-url' => 'https://example.com'}) }.to raise_error("'cacert' is required in config")

--- a/spec/unit/orchestrator_client_spec.rb
+++ b/spec/unit/orchestrator_client_spec.rb
@@ -48,9 +48,15 @@ describe OrchestratorClient do
       token_file.write("oops\nbadchars")
       token_file.flush
       @config['token-file'] = token_file.path
-      expect{ OrchestratorClient.new(@config) }.to raise_error("'#{token_file.path}' contains illegal characters")
+      expect{ OrchestratorClient.new(@config) }.to raise_error("token-file '#{token_file.path}' contains illegal characters")
       token_file.close
       token_file.unlink
+    end
+
+    it "complains when token-file cannot be read" do
+      @config.delete('token')
+      @config['token-file'] = '/bad/path'
+      expect{ OrchestratorClient.new(@config) }.to raise_error("token-file '#{@config['token-file']}' is unreadable")
     end
   end
 


### PR DESCRIPTION
After releasing this change and attempting to incorporate with Bolt we discovered that the implementation has a dependency on https://github.com/drbrain/net-http-persistent which is is currently not compatible with Bolt on windows. Due to incompatibility of the net-http-persistent gem with windows only use the persistent http functionality on non-windows OS.
