### PR TITLE
(GH-2518) Add read-timeout configuration option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,6 @@ end
 
 group :development do
   gem 'pry'
+  gem 'pry-stack_explorer'
+  gem 'pry-byebug'
 end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A simple client for interacting with the Orchestration Services API in Puppet En
 
 ## Compatibility
 
-Currently, this client supports the "V1" endpoints shipped as part of Puppet Enterprise 2016.2.
+Currently, this client supports the "V1" endpoints shipped as part of Puppet Enterprise 2016.2 -
+2019.8.4.
 
 ## Installation
 
@@ -28,6 +29,7 @@ expected to be at `~/.puppetlabs/token` which is the default location used by
 * `User-Agent`- Set `User-Agent` header for HTTP requests. Defaults to `OrchestratorRubyClient/[VERSION]`
 * `job-poll-interval`- Set the default amount of time to sleep when polling in Orchestrator::Job#wait and #each\_event
 * `job-poll-timeout`- Set the default maximum amount of time to wait in Orchestrator::Job#wait
+* `read-timeout` - The time to wait before raising a Timeout exception when making HTTP requests.
 
 ### Example
 
@@ -68,10 +70,6 @@ issues](https://github.com/puppetlabs/orchestrator_api-ruby/issues).
 
 If you are interested in contributing to this project, please see the
 [Contribution Guidelines](CONTRIBUTING.md)
-
-## Authors
-
-Tom Linkin <tom@puppet.com>
 
 ## License
 

--- a/lib/orchestrator_client.rb
+++ b/lib/orchestrator_client.rb
@@ -33,6 +33,7 @@ class OrchestratorClient
       else
         f.adapter :net_http_persistent, pool_size: 5 do |http|
           http.idle_timeout = 30
+          http.read_timeout = config['read-timeout'] if config['read-timeout']
         end
       end
     end

--- a/lib/orchestrator_client/version.rb
+++ b/lib/orchestrator_client/version.rb
@@ -1,3 +1,3 @@
 class OrchestratorClient
-  VERSION = '0.4.3'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/spec/unit/orchestrator_client_spec.rb
+++ b/spec/unit/orchestrator_client_spec.rb
@@ -18,7 +18,6 @@ describe OrchestratorClient do
       expect(@orchestrator_api).to be_an_instance_of OrchestratorClient
     end
 
-
     it "has methods with objects that are not nil" do
       expect(@orchestrator_api.command).to be_truthy
       expect(@orchestrator_api.jobs).to be_truthy
@@ -44,6 +43,27 @@ describe OrchestratorClient do
       @config['cacert'] = '~/bad/path'
       expect{ OrchestratorClient.new(@config) }.to raise_error("cacert '#{Dir.home}/bad/path' does not exist")
     end
+  end
+
+  it "sets read_timeout" do
+    expect_any_instance_of(Net::HTTP::Persistent).to receive(:read_timeout=).and_call_original
+    @config['read-timeout'] = 10
+    client = OrchestratorClient.new(@config)
+    stub_request(:get, "https://orchestrator.example.lan:8143/orchestrator/v1/endpoint").
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>"OrchestratorRubyClient/#{OrchestratorClient::VERSION}", 'X-Authentication'=>'myfaketoken'}).
+      to_return(:status => 200, :body => "{}", :headers => {})
+
+    client.get('endpoint')
+  end
+
+  it "does not set read_timeout if not specified" do
+    expect_any_instance_of(Net::HTTP::Persistent).not_to receive(:read_timeout=)
+    client = OrchestratorClient.new(@config)
+    stub_request(:get, "https://orchestrator.example.lan:8143/orchestrator/v1/endpoint").
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>"OrchestratorRubyClient/#{OrchestratorClient::VERSION}", 'X-Authentication'=>'myfaketoken'}).
+      to_return(:status => 200, :body => "{}", :headers => {})
+
+    client.get('endpoint')
   end
 
   context "When loading a token from file" do


### PR DESCRIPTION
This adds a `read-timeout` configuration option which sets
`read_timeout` on the `Net::Http::Persistent` connection. This
configures the [seconds to wait until reading one
block](https://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html#attribute-i-read_timeout),
which throws a `Net::ReadTimeout` error if there's nothing to read in
that time. This configuration option is exposed in Bolt when using the
PCP transport.

    
`Net::Http::Persistent#read_timeout=` should not be called if
`read-timeout` is not configured as there is no default for it (at least
that I could find).