### PR TITLE
(GH-29) Use regex to validate token file input

### DIFF
--- a/.github/workflows/spec.yaml
+++ b/.github/workflows/spec.yaml
@@ -1,0 +1,23 @@
+name: Spec tests
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+
+  spec:
+    name: Spec test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7 
+          bundler-cache: true
+      - name: Update gems
+        run: bundle update
+      - name: Run tests
+        run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ issues](https://github.com/puppetlabs/orchestrator_api-ruby/issues).
 If you are interested in contributing to this project, please see the
 [Contribution Guidelines](CONTRIBUTING.md)
 
+## Releasing
+
+Use the
+https://cinext-jenkinsmaster-sre-prod-1.delivery.puppetlabs.net/job/qe_orchestrator-client-ruby_init-multijob_master/
+job to release. This pipeline will update the [version file](lib/orchestrator_client/version.rb),
+create the tag you specify, and push release [to
+rubygems](https://rubygems.org/gems/orchestrator_client).
+
 ## License
 
 See LICENSE.

--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -98,7 +98,8 @@ class OrchestratorClient::Config
     else
       validate_file('token-file', config['token-file'])
       token = File.open(config['token-file']) { |f| f.read.strip }
-      if token != URI.escape(token)
+      # If the token file contains illegal characters
+      if token =~ URI::UNSAFE
         raise OrchestratorClient::ConfigError.new("token-file '#{config['token-file']}' contains illegal characters")
       end
       @config['token'] = token


### PR DESCRIPTION
Previously we were using `URI.escape` to [verify that the provided
tokenfile path configuration didn't contain illegal
characters](https://github.com/puppetlabs/orchestrator_client-ruby/commit/3f100911622a94b80edebf8a976620b1edfc3993).
The method now raises a warning when called [as of
Ruby2.7](https://stackoverflow.com/questions/65423458/ruby-2-7-says-uri-escape-is-obsolete-what-replaces-it),
but the Orchestrator client was only using the function to verify that
no illegal characters were in the provided string. The way that
`URI.escape` worked [by default was using the 
constant](https://stackoverflow.com/questions/34274838/why-is-uri-escape-marked-as-obsolete-and-where-is-this-regexpunsafe-constant)
`URI::UNSAFE` which is a regex to scan for illegal characters. Rather
than having to do [piecemeal URI
validation](https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string)
we can simply use the `URI::UNSAFE` constant to check the string in the
same way we were before.

This also pulls in #22 and rebases so there's no merge conflict.

Closes #29
