### PR TITLE
(maint) Bump net-http-persistent to ~> 4.0

### DIFF
--- a/orchestrator_client.gemspec
+++ b/orchestrator_client.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'faraday', '~> 1.4'
-  s.add_dependency 'net-http-persistent', '~> 3.1'
+  s.add_dependency 'net-http-persistent', '~> 4.0'
 end


### PR DESCRIPTION
This bumps net-http-persistent to ~> 4.0, as the latest version of
faraday-net_http_persistent uses that version and both bolt and
bolt-server ship with those versions.