### PR TITLE
README.md: Fix constructor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ require 'orchestrator_client'
 # Requires at least a server name and path to the CA certificate
 
 client = OrchestratorClient.new({
-                                'service-url' => 'https://orchestrator.example.lan:8143/orchestrator/v1',
+                                'service-url' => 'https://orchestrator.example.lan:8143',
                                 'cacert'     => '/path/to/cert'
                               })
 


### PR DESCRIPTION
People must only provide the base url. the lib will append the rest: https://github.com/puppetlabs/orchestrator_client-ruby/blob/ce9cd065a0e1af3b26727b6edcbeff4cb43ea758/lib/orchestrator_client/config.rb#L118