### PR TITLE
(maint) Replace deprecated File.exists? method

### DIFF
--- a/lib/orchestrator_client/config.rb
+++ b/lib/orchestrator_client/config.rb
@@ -44,13 +44,13 @@ class OrchestratorClient::Config
   def load_config
     config = defaults
     if @load_files
-      if File.exists?(global_conf) && File.readable?(global_conf)
+      if File.exist?(global_conf) && File.readable?(global_conf)
         config = config.merge(load_file(global_conf))
       end
 
       if @overrides['config-file']
         config = config.merge(load_file(@overrides['config-file']))
-      elsif File.exists?(user_conf) && File.readable?(user_conf)
+      elsif File.exist?(user_conf) && File.readable?(user_conf)
         config = config.merge(load_file(user_conf))
       end
     end


### PR DESCRIPTION
Ruby 3.2 dropped support for File.exists? This PR updates the orchestrator-client to use File.exist? to be ruby 3.2 compliant.