### PR TITLE
(PE-41918) Configure net-http read_timeout on Windows

### DIFF
--- a/lib/orchestrator_client.rb
+++ b/lib/orchestrator_client.rb
@@ -28,9 +28,12 @@ class OrchestratorClient
       f.headers['User-Agent'] = config['User-Agent']
       f.ssl['ca_file'] = config['cacert']
       f.ssl['version'] = :TLSv1_2
-      # Do not use net-http-persistent on windows
+      # net-http-persistent does not work reliably on Windows, so fall back
+      # to net-http
       if !!File::ALT_SEPARATOR
-        f.adapter :net_http
+        f.adapter :net_http do |http|
+          http.read_timeout = config['read-timeout'] if config['read-timeout']
+        end
       else
         f.adapter :net_http_persistent, pool_size: 5 do |http|
           http.idle_timeout = 30


### PR DESCRIPTION
This passes the `read-timeout` config to the net-http client when running on Windows. Previously, this option was not being set, causing the client to drop the connection once the default timeout of 60s was reached.