### PR TITLE
(PE-44632) Require faraday-net_http_persistent >= 2.0

### DIFF
--- a/orchestrator_client.gemspec
+++ b/orchestrator_client.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'faraday', '>= 1.4', '< 3.0'
-  s.add_dependency 'faraday-net_http_persistent', '>= 1.0', '< 3.0'
+  s.add_dependency 'faraday-net_http_persistent', '>= 2.0', '< 3.0'
 end


### PR DESCRIPTION
## Summary

`orchestrator_client.gemspec` allowed `faraday-net_http_persistent >= 1.0` alongside `faraday >= 1.4, < 3.0`. Bundler could pair faraday v2.x with the v1.x adapter, which is incompatible: the v1.x adapter calls `Faraday::Adapter.dependency` in its class body — an API faraday v2 removed — so `require 'faraday/net_http_persistent'` raises `NoMethodError` at load time.

This crashed `puppet-infra run rebuild_certificate_authority` (and other PCP/orchestrator-transport Bolt plans) in the PE installer, failing the `lei-cert-regen-task` nightly on all redhat-8 cells.

## Fix

Floor `faraday-net_http_persistent` at `>= 2.0` so bundler resolves the faraday v2-compatible adapter (`< 3.0` upper bound unchanged).

```diff
-  s.add_dependency 'faraday-net_http_persistent', '>= 1.0', '< 3.0'
+  s.add_dependency 'faraday-net_http_persistent', '>= 2.0', '< 3.0'
```

## Testing

- Existing rspec suite green (54 examples, 0 failures).
- Verified the gemspec dependency now rejects `1.2.0` and accepts `2.3.1`.

Jira: https://perforce.atlassian.net/browse/PE-44632

🤖 Generated with [Claude Code](https://claude.com/claude-code)